### PR TITLE
Project skeleton for PHP Runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/composer.lock
+/composer.phar
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+dist: trusty
+
+language: php
+
+php:
+  - 7.4
+  - nightly
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+
+matrix:
+  allow_failures:
+    - php: nightly
+  fast_finish: true
+
+sudo: false
+
+install:
+  - composer install
+
+script:
+  - composer test

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,31 @@
+{
+  "name": "dafny/runtime",
+  "description": "Runtime features for PHP programs compiled from Dafny",
+  "authors": [
+    {
+      "name": "Amazon Web Services",
+      "homepage": "http://aws.amazon.com"
+    }
+  ],
+  "license": "MIT",
+  "autoload": {
+    "psr-4": {
+      "Dafny\\Runtime\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Dafny\\Runtime\\Tests\\": "tests/"
+    }
+  },
+  "require": {
+    "php": ">= 7.4"
+  },
+  "scripts": {
+    "test": "phpunit && psalm"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9",
+    "vimeo/psalm": "^3"
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.4/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/src/Dafny.php
+++ b/src/Dafny.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+namespace Dafny\Runtime;
+
+/**
+ * Class Dafny
+ * @package Dafny\Runtime
+ */
+class Dafny
+{
+    /**
+     * @param string|bool|int|float|null|array|object $expr
+     * @return string
+     */
+    public static function toString($expr): string
+    {
+        if (is_null($expr)) {
+            return 'null';
+        }
+        if (is_bool($expr)) {
+            return $expr ? 'true' : 'false';
+        }
+        if (is_array($expr)) {
+            return var_export($expr, true);
+        }
+        if (is_object($expr)) {
+            return var_export($expr, true);
+        }
+        if (is_string($expr)) {
+            return $expr;
+        }
+        return (string) $expr;
+    }
+}

--- a/tests/DafnyTest.php
+++ b/tests/DafnyTest.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+namespace Dafny\Runtime\Tests;
+
+use Dafny\Runtime\Dafny;
+use PHPUnit\Framework\TestCase;
+
+class DafnyTest extends TestCase
+{
+    public function testDafnyTostring()
+    {
+        $this->assertSame('true', Dafny::toString(true));
+        $this->assertSame('false', Dafny::toString(false));
+
+    }
+}


### PR DESCRIPTION
This adds the following:

1. Composer file, so we can add the PHP Runtime for Dafny to Packagist and use it in Dafny-compiled projects.
2. Test suites.
   * Unit tests powered via PHPUnit.
   * Static analysis test powered by Psalm.
3. `Dafny::toString()`, which will help with the PHP compiler in https://github.com/dafny-lang/dafny/pull/519